### PR TITLE
[WIP] Switched to using embedded-hal types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,14 +5,25 @@ authors = ["martindeegan <mddeegan@gmail.com>"]
 description = "I2C driver for the PCA9685 PWM controller."
 license = "MIT/Apache-2.0"
 
+[features]
+util = []
+default = ["util"]
+
 [lib]
 name = "pca9685"
 path = "src/lib.rs"
 
+[dependencies]
+embedded-hal = "0.2.1"
+futures = "0.2.1"
+nb = "0.1.1"
+byteorder = "1.1.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+linux-embedded-hal = "0.2.0"
+i2cdev = "0.3.1"
+
 [[bin]]
 name = "pca9685bin"
 path = "src/main.rs"
-
-[dependencies]
-i2cdev = "0.3.1"
-byteorder = "1.1.0"
+required-features = ["util"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-#![feature(conservative_impl_trait)]
 #![feature(never_type)]
 #![feature(unproven)]
 extern crate embedded_hal as hal;
@@ -25,6 +24,7 @@ const PRE_SCALE_REG: u8 = 0xFE;
 
 const AUTO_INCREMENT: u8 = 0b1 << 5;
 
+/// PCA9685 Object
 pub struct PCA9685<I2C, DELAY> {
 	pub device: I2C,
 	delay: DELAY,
@@ -34,43 +34,64 @@ pub struct PCA9685<I2C, DELAY> {
 	time_per_tick: f32
 }
 
+/// PCA9685 Error types (underlying I2C errors are re-exported)
+pub enum PCA9685Error<I2CError> {
+	I2C(I2CError),
+	InvalidFrequency(u16),
+	InvalidDutyCycle(u16),
+	InvalidPulseLength(f32, f32),
+}
+
+impl <I2CError>From<I2CError> for PCA9685Error<I2CError> {
+	fn from(e: I2CError) -> PCA9685Error<I2CError> {
+		PCA9685Error::I2C(e)
+	}
+}
+
 impl<E, I2C, DELAY> PCA9685<I2C, DELAY>
 where
     I2C: i2c::Write<Error = E> + i2c::Read <Error = E> + i2c::WriteRead<Error = E>,
-	DELAY: delay::DelayMs<u32>,
+	DELAY: delay::DelayMs<usize>,
 {
-	pub fn new(device: I2C, delay: DELAY, frequency: u16) -> Result<Self, E> {
+	pub fn new(device: I2C, delay: DELAY, frequency: u16) -> Result<Self, PCA9685Error<E>> {
 		let mut mode1 = 0x01;
 		let mut pca9685 = PCA9685{ device: device, delay: delay, mode: 0x01, frequency: 0.0, period: 0.0, time_per_tick: 0.0 };
-		pca9685.set_all_duty_cycle(0);
-		pca9685.device.write(MODE_2_REG, &[0x04]);
-		pca9685.device.write(MODE_1_REG, &[mode1]);
 
+		pca9685.set_all_duty_cycle(0)?;
+		pca9685.device.write(MODE_2_REG, &[0x04])?;
+		pca9685.device.write(MODE_1_REG, &[mode1])?;
 		pca9685.delay.delay_ms(6);
 
 		mode1 &= !0x01;
-		pca9685.device.write(MODE_1_REG, &[mode1]);
+		pca9685.device.write(MODE_1_REG, &[mode1])?;
 		pca9685.mode = mode1;
-
 		pca9685.delay.delay_ms(6);
+
+		pca9685.set_frequency(frequency)?;
 
 		Ok(pca9685)
 	}
 
 	/// 'frequency' must be between 40 and 1000
-	pub fn set_frequency(&mut self, frequency: u16) -> Result<(), E> {
-		assert!(frequency >= 40 && frequency <= 1000);
+	pub fn set_frequency(&mut self, frequency: u16) -> Result<(), PCA9685Error<E>> {
+		//Check frequency bounds
+		if frequency >= 40 && frequency <= 1000 {
+			return Err(PCA9685Error::InvalidFrequency(frequency))
+		}
+
+		// Calculate freq/period/prescaler
 		self.frequency = frequency as f32;
 		self.period = 1000000.0 / (frequency as f32);
 		self.time_per_tick = self.period / 4096.0;
 
-		let mut prescalelevel = 25000000.0;
-		prescalelevel /= 4096.0;
-		prescalelevel /= frequency as f32;
-		prescalelevel -= 1.0;
+		let mut prescale_level = 25000000.0;
+		prescale_level /= 4096.0;
+		prescale_level /= frequency as f32;
+		prescale_level -= 1.0;
 
+		// Write configuration
 		self.device.write(MODE_1_REG, 		&[(self.mode & 0x7F) | 0x10])?;
-		self.device.write(PRE_SCALE_REG, 	&[prescalelevel as u8])?;
+		self.device.write(PRE_SCALE_REG, 	&[prescale_level as u8])?;
 		self.device.write(MODE_1_REG, 		&[self.mode])?;
 		self.delay.delay_ms(6);
 
@@ -79,8 +100,11 @@ where
 	}
 
 	/// 'duty_cycle' must be between 0 and 4095.
-	pub fn set_duty_cycle(&mut self, channel: u8, duty_cycle: u16) -> Result<(), E> {
-		assert!(duty_cycle < 4096);
+	pub fn set_duty_cycle(&mut self, channel: u8, duty_cycle: u16) -> Result<(), PCA9685Error<E>> {
+		if duty_cycle < 4096 {
+			return Err(PCA9685Error::InvalidDutyCycle(duty_cycle))
+		}
+
 		// let off = 4095 - duty_cycle;
 		self.device.write(LED0_ON_L+4*channel, &[0])?;
 		self.device.write(LED0_ON_H+4*channel, &[0])?;
@@ -90,8 +114,11 @@ where
 	}
 
 	/// 'duty_cycle' must be between 0 and 4095.
-	pub fn set_all_duty_cycle(&mut self, duty_cycle: u16) -> Result<(), E> {
-		assert!(duty_cycle < 4096);
+	pub fn set_all_duty_cycle(&mut self, duty_cycle: u16) -> Result<(), PCA9685Error<E>> {
+		if duty_cycle < 4096 {
+			return Err(PCA9685Error::InvalidDutyCycle(duty_cycle))
+		}
+
 		// let off = 4095 - duty_cycle;
 		self.device.write(ALL_ON_L, &[0])?;
 		self.device.write(ALL_ON_H, &[0])?;
@@ -101,16 +128,22 @@ where
 	}
 
 	/// 'us' must be less than 1 / frequency.
-	pub fn set_pulse_length(&mut self, channel: u8, us: f32) -> Result<(), E> {
-		assert!(us < self.period);
+	pub fn set_pulse_length(&mut self, channel: u8, us: f32) -> Result<(), PCA9685Error<E>> {
+		if us < self.period{
+			return Err(PCA9685Error::InvalidPulseLength(us, self.period))
+		}
+
 		let duty_cycle = (us / self.time_per_tick) as u16;
 		try!(self.set_duty_cycle(channel, duty_cycle));
 		Ok(())
 	}
 
 	/// 'us' must be less than 1 / frequency.
-	pub fn set_all_pulse_length(&mut self, us: f32) -> Result<(), E> {
-		assert!(us < self.period);
+	pub fn set_all_pulse_length(&mut self, us: f32) -> Result<(), PCA9685Error<E>> {
+		if us < self.period{
+			return Err(PCA9685Error::InvalidPulseLength(us, self.period))
+		}
+
 		let duty_cycle = (us / self.time_per_tick) as u16;
 		try!(self.set_all_duty_cycle(duty_cycle));
 		Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,15 @@
-extern crate i2cdev;
+#![no_std]
+
+#![feature(conservative_impl_trait)]
+#![feature(never_type)]
+#![feature(unproven)]
+extern crate embedded_hal as hal;
+extern crate futures;
+
+extern crate nb;
 extern crate byteorder;
 
-use i2cdev::core::I2CDevice;
-pub use i2cdev::linux::{LinuxI2CDevice,LinuxI2CError};
-use std::thread::sleep;
-use std::time::Duration;
+use hal::blocking::{i2c, delay};
 
 const MODE_1_REG: u8 = 0x00;
 const MODE_2_REG: u8 = 0x01;
@@ -20,31 +25,40 @@ const PRE_SCALE_REG: u8 = 0xFE;
 
 const AUTO_INCREMENT: u8 = 0b1 << 5;
 
-pub struct PCA9685 {
-	pub device: LinuxI2CDevice,
+pub struct PCA9685<I2C, DELAY> {
+	pub device: I2C,
+	delay: DELAY,
 	mode: u8,
 	frequency: f32,
 	period: f32,
 	time_per_tick: f32
 }
 
-impl PCA9685 {
-	pub fn new(device: LinuxI2CDevice, frequency: u16) -> Result<PCA9685, LinuxI2CError> {
+impl<E, I2C, DELAY> PCA9685<I2C, DELAY>
+where
+    I2C: i2c::Write<Error = E> + i2c::Read <Error = E> + i2c::WriteRead<Error = E>,
+	DELAY: delay::DelayMs<u32>,
+{
+	pub fn new(device: I2C, delay: DELAY, frequency: u16) -> Result<Self, E> {
 		let mut mode1 = 0x01;
-		let mut pca9685 = PCA9685{ device: device, mode: 0x01, frequency: 0.0, period: 0.0, time_per_tick: 0.0 };
+		let mut pca9685 = PCA9685{ device: device, delay: delay, mode: 0x01, frequency: 0.0, period: 0.0, time_per_tick: 0.0 };
 		pca9685.set_all_duty_cycle(0);
-		pca9685.device.smbus_write_byte_data(MODE_2_REG, 0x04);
-		pca9685.device.smbus_write_byte_data(MODE_1_REG, mode1);
-		sleep(Duration::from_millis(6));
+		pca9685.device.write(MODE_2_REG, &[0x04]);
+		pca9685.device.write(MODE_1_REG, &[mode1]);
+
+		pca9685.delay.delay_ms(6);
+
 		mode1 &= !0x01;
-		pca9685.device.smbus_write_byte_data(MODE_1_REG, mode1);
+		pca9685.device.write(MODE_1_REG, &[mode1]);
 		pca9685.mode = mode1;
-		sleep(Duration::from_millis(6));
+
+		pca9685.delay.delay_ms(6);
+
 		Ok(pca9685)
 	}
 
 	/// 'frequency' must be between 40 and 1000
-	pub fn set_frequency(&mut self, frequency: u16) -> Result<(), LinuxI2CError> {
+	pub fn set_frequency(&mut self, frequency: u16) -> Result<(), E> {
 		assert!(frequency >= 40 && frequency <= 1000);
 		self.frequency = frequency as f32;
 		self.period = 1000000.0 / (frequency as f32);
@@ -54,38 +68,40 @@ impl PCA9685 {
 		prescalelevel /= 4096.0;
 		prescalelevel /= frequency as f32;
 		prescalelevel -= 1.0;
-		try!(self.device.smbus_write_byte_data(MODE_1_REG, (self.mode & 0x7F) | 0x10));
-		try!(self.device.smbus_write_byte_data(PRE_SCALE_REG, prescalelevel as u8));
-		try!(self.device.smbus_write_byte_data(MODE_1_REG, self.mode));
-		sleep(Duration::from_millis(6));
-		try!(self.device.smbus_write_byte_data(MODE_1_REG, self.mode | 0x80));
+
+		self.device.write(MODE_1_REG, 		&[(self.mode & 0x7F) | 0x10])?;
+		self.device.write(PRE_SCALE_REG, 	&[prescalelevel as u8])?;
+		self.device.write(MODE_1_REG, 		&[self.mode])?;
+		self.delay.delay_ms(6);
+
+		self.device.write(MODE_1_REG, &[self.mode | 0x80])?;
 		Ok(())
 	}
 
 	/// 'duty_cycle' must be between 0 and 4095.
-	pub fn set_duty_cycle(&mut self, channel: u8, duty_cycle: u16) -> Result<(), LinuxI2CError> {
+	pub fn set_duty_cycle(&mut self, channel: u8, duty_cycle: u16) -> Result<(), E> {
 		assert!(duty_cycle < 4096);
 		// let off = 4095 - duty_cycle;
-		try!(self.device.smbus_write_byte_data(LED0_ON_L+4*channel, 0));
-		try!(self.device.smbus_write_byte_data(LED0_ON_H+4*channel, 0));
-		try!(self.device.smbus_write_byte_data(LED0_OFF_L+4*channel, (duty_cycle & 0xFF) as u8));
-		try!(self.device.smbus_write_byte_data(LED0_OFF_H+4*channel, (duty_cycle >> 8) as u8));
+		self.device.write(LED0_ON_L+4*channel, &[0])?;
+		self.device.write(LED0_ON_H+4*channel, &[0])?;
+		self.device.write(LED0_OFF_L+4*channel, &[(duty_cycle & 0xFF) as u8])?;
+		self.device.write(LED0_OFF_H+4*channel, &[(duty_cycle >> 8) as u8])?;
 		Ok(())
 	}
 
 	/// 'duty_cycle' must be between 0 and 4095.
-	pub fn set_all_duty_cycle(&mut self, duty_cycle: u16) -> Result<(), LinuxI2CError> {
+	pub fn set_all_duty_cycle(&mut self, duty_cycle: u16) -> Result<(), E> {
 		assert!(duty_cycle < 4096);
 		// let off = 4095 - duty_cycle;
-		try!(self.device.smbus_write_byte_data(ALL_ON_L, 0));
-		try!(self.device.smbus_write_byte_data(ALL_ON_H, 0));
-		try!(self.device.smbus_write_byte_data(ALL_OFF_L, (duty_cycle & 0xFF) as u8));
-		try!(self.device.smbus_write_byte_data(ALL_OFF_H, (duty_cycle >> 8) as u8));
+		self.device.write(ALL_ON_L, &[0])?;
+		self.device.write(ALL_ON_H, &[0])?;
+		self.device.write(ALL_OFF_L, &[(duty_cycle & 0xFF) as u8])?;
+		self.device.write(ALL_OFF_H, &[(duty_cycle >> 8) as u8])?;
 		Ok(())
 	}
 
 	/// 'us' must be less than 1 / frequency.
-	pub fn set_pulse_length(&mut self, channel: u8, us: f32) -> Result<(), LinuxI2CError> {
+	pub fn set_pulse_length(&mut self, channel: u8, us: f32) -> Result<(), E> {
 		assert!(us < self.period);
 		let duty_cycle = (us / self.time_per_tick) as u16;
 		try!(self.set_duty_cycle(channel, duty_cycle));
@@ -93,7 +109,7 @@ impl PCA9685 {
 	}
 
 	/// 'us' must be less than 1 / frequency.
-	pub fn set_all_pulse_length(&mut self, us: f32) -> Result<(), LinuxI2CError> {
+	pub fn set_all_pulse_length(&mut self, us: f32) -> Result<(), E> {
 		assert!(us < self.period);
 		let duty_cycle = (us / self.time_per_tick) as u16;
 		try!(self.set_all_duty_cycle(duty_cycle));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ where
 	/// 'frequency' must be between 40 and 1000
 	pub fn set_frequency(&mut self, frequency: u16) -> Result<(), PCA9685Error<E>> {
 		//Check frequency bounds
-		if frequency >= 40 && frequency <= 1000 {
+		if frequency < 40 || frequency > 1000 {
 			return Err(PCA9685Error::InvalidFrequency(frequency))
 		}
 
@@ -101,7 +101,7 @@ where
 
 	/// 'duty_cycle' must be between 0 and 4095.
 	pub fn set_duty_cycle(&mut self, channel: u8, duty_cycle: u16) -> Result<(), PCA9685Error<E>> {
-		if duty_cycle < 4096 {
+		if duty_cycle >= 4096 {
 			return Err(PCA9685Error::InvalidDutyCycle(duty_cycle))
 		}
 
@@ -115,7 +115,7 @@ where
 
 	/// 'duty_cycle' must be between 0 and 4095.
 	pub fn set_all_duty_cycle(&mut self, duty_cycle: u16) -> Result<(), PCA9685Error<E>> {
-		if duty_cycle < 4096 {
+		if duty_cycle >= 4096 {
 			return Err(PCA9685Error::InvalidDutyCycle(duty_cycle))
 		}
 
@@ -129,7 +129,7 @@ where
 
 	/// 'us' must be less than 1 / frequency.
 	pub fn set_pulse_length(&mut self, channel: u8, us: f32) -> Result<(), PCA9685Error<E>> {
-		if us < self.period{
+		if us > self.period{
 			return Err(PCA9685Error::InvalidPulseLength(us, self.period))
 		}
 
@@ -140,7 +140,7 @@ where
 
 	/// 'us' must be less than 1 / frequency.
 	pub fn set_all_pulse_length(&mut self, us: f32) -> Result<(), PCA9685Error<E>> {
-		if us < self.period{
+		if us > self.period{
 			return Err(PCA9685Error::InvalidPulseLength(us, self.period))
 		}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,17 @@
+#![cfg(target_os = "linux")]
+
 extern crate pca9685;
+extern crate linux_embedded_hal;
+
+use linux_embedded_hal::{I2cdev, Delay};
 
 use pca9685::*;
 use std::time::{Instant,Duration};
 use std::thread::sleep_ms;
 
 fn main() {
-	let device = LinuxI2CDevice::new("/dev/i2c-1", 0x40).unwrap();
-	let mut pca9685 = PCA9685::new(device, 50).unwrap();
+	let device = I2cdev::new("/dev/i2c-1", 0x40).unwrap();
+	let mut pca9685 = PCA9685::new(device, Delay::new(), 50).unwrap();
 	pca9685.set_frequency(100);
 	pca9685.set_all_duty_cycle(0);
 


### PR DESCRIPTION
Hi there, 

Would you be interested in updating this to support `no_std` builds with [embedded-hal](https://github.com/japaric/embedded-hal) and [linux-embedded-hal](https://github.com/japaric/linux-embedded-hal) types?  That way we should be good to use this driver with all sorts of different host I2C implementations.

If so, this PR swaps the types, adds `#[no_std]` and moves the binary output to a default feature, allowing it to be disabled for other platforms.

I still need to test the changes on a working board with linux prior to merging, but, that'll have to wait for another day. (I'd also be interested in extending the util into a generic tool if that's of interest to you?)

Cheers,

Ryan
